### PR TITLE
chore: VS Code 테마 강제 해제

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "workbench.colorTheme": "Default Light+",
   "git.autofetch": true,
   "editor.wordWrap": "on",
   "git.openRepositoryInParentFolders": "never",


### PR DESCRIPTION
기존 .vscode/settings.json 경로에서 아래 코드를 제거하여 ide의 default color설정을 해제
`"workbench.colorTheme": "Default Light+",`