### PR TITLE
찜 목록 페이지 구현

### DIFF
--- a/web/src/pages/FindSheltersPage/hooks/useShelters.ts
+++ b/web/src/pages/FindSheltersPage/hooks/useShelters.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { nearbyShelters } from '@/mock/nearbyShelters';
+import { toggleWish } from '@/utils/wishApi';
 
 const ITEMS_PER_PAGE = 3;
 
@@ -11,45 +12,43 @@ export const useShelters = () => {
 
   const hasMoreItems = visibleCount < nearbyShelters.length;
 
-  // 스크롤 이벤트를 window에서 감지하도록 수정한 useEffect
   useEffect(() => {
     const handleScroll = () => {
-      // 스크롤 위치가 최상단이 아닐 경우 showScrollToTop을 true로 설정
       if (window.scrollY > 0) {
         setShowScrollToTop(true);
       } else {
         setShowScrollToTop(false);
       }
     };
-
-    // window 객체에 스크롤 이벤트 리스너 추가
     window.addEventListener('scroll', handleScroll);
-
-    // 컴포넌트가 사라질 때 window의 이벤트 리스너를 제거
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []); // 컴포넌트 마운트 시 한 번만 실행
+  }, []);
 
-  // TODO: 낙관적 업데이트 or 로그인 사용자만 가능하도록 수정 필요
-  // '좋아요' 버튼 클릭 핸들러
-  const handleToggleFavorite = (shelterId: number) => {
+  // wishApi를 활용한 찜 버튼 클릭 핸들러
+  const handleToggleFavorite = async (shelterId: number, userId: number = 1) => {
     const isAlreadyFavorite = favoriteIds.includes(shelterId);
 
-    if (isAlreadyFavorite) {
-      setFavoriteIds((prev) => prev.filter((id) => id !== shelterId));
-      setToastMessage('찜 목록에서\n삭제되었습니다.');
-    } else {
-      setFavoriteIds((prev) => [...prev, shelterId]);
-      setToastMessage('찜 목록에\n추가되었습니다.');
+    const result = await toggleWish({
+      shelterId,
+      userId,
+      isFavorite: isAlreadyFavorite,
+    });
+
+    if (result.success) {
+      if (isAlreadyFavorite) {
+        setFavoriteIds((prev) => prev.filter((id) => id !== shelterId));
+      } else {
+        setFavoriteIds((prev) => [...prev, shelterId]);
+      }
     }
+    setToastMessage(result.message);
     setTimeout(() => setToastMessage(''), 2000);
   };
 
-  // '더보기' 버튼 클릭 핸들러
   const handleLoadMore = () => {
     setVisibleCount((prevCount) => prevCount + ITEMS_PER_PAGE);
   };
 
-  // '맨 위로 가기' 버튼 클릭 시 window를 스크롤
   const handleScrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };

--- a/web/src/pages/FindSheltersPage/hooks/useShelters.ts
+++ b/web/src/pages/FindSheltersPage/hooks/useShelters.ts
@@ -25,6 +25,7 @@ export const useShelters = () => {
   }, []);
 
   // wishApi를 활용한 찜 버튼 클릭 핸들러
+  // TODO: userId는 실제 서비스에서는 인증 정보에서 받아야 함
   const handleToggleFavorite = async (shelterId: number, userId: number = 1) => {
     const isAlreadyFavorite = favoriteIds.includes(shelterId);
 

--- a/web/src/pages/ShelterDetailPage/components/ShelterReviewSection.tsx
+++ b/web/src/pages/ShelterDetailPage/components/ShelterReviewSection.tsx
@@ -51,22 +51,18 @@ const ShelterReviewSection = ({
     if (!el) return;
     const lineHeight = parseFloat(getComputedStyle(el).lineHeight || '20');
     const maxHeight = lineHeight * 3;
-    // 3줄 초과면 showMoreMap[reviewId] = true
+    // 3줄 초과면 true, 3줄 이하면 false
     setShowMoreMap((prev) => ({
       ...prev,
-      [reviewId]: el.scrollHeight > maxHeight,
+      [reviewId]: el.scrollHeight > maxHeight + 1, // +1로 오차 보정
     }));
   };
 
   // 화면 크기 변경 시 줄 수 재확인
   useEffect(() => {
-    const handleResize = () => {
+    setTimeout(() => {
       reviews.forEach((r) => checkLineClamp(r.reviewId));
-    };
-    window.addEventListener('resize', handleResize);
-    // mount 시에도 체크
-    reviews.forEach((r) => checkLineClamp(r.reviewId));
-    return () => window.removeEventListener('resize', handleResize);
+    }, 0);
   }, [reviews]);
 
   return (

--- a/web/src/pages/ShelterDetailPage/hooks/useShelterDetail.ts
+++ b/web/src/pages/ShelterDetailPage/hooks/useShelterDetail.ts
@@ -146,6 +146,7 @@ export const useShelterDetail = (id: string | undefined) => {
     shelter,
     isLoading: !shelter, // 쉼터 정보가 로드되기 전까지 로딩 상태로 간주
     isFavorite,
+    setIsFavorite, //isFavorite 상태를 직접 변경할 수 있도록 반환
     reviews,
     loadingReviews,
     visibleCount,

--- a/web/src/pages/ShelterDetailPage/index.tsx
+++ b/web/src/pages/ShelterDetailPage/index.tsx
@@ -6,11 +6,11 @@ import ToastMessage from '../FindSheltersPage/components/ToastMessage';
 import ShelterDetailInfo from './components/ShelterDetailInfo';
 import ShelterReviewSection from './components/ShelterReviewSection';
 import { useShelterDetail } from './hooks/useShelterDetail';
+import { toggleWish } from '@/utils/wishApi';
 
 const ShelterDetailPage = () => {
   const { id } = useParams();
 
-  // 커스텀 훅을 호출하여 페이지에 필요한 모든 데이터를 가져옴
   const {
     shelter,
     isLoading,
@@ -21,11 +21,10 @@ const ShelterDetailPage = () => {
     averageRating,
     handleImageError,
     handleMore,
-    onToggleFavorite,
     onGuideStart,
+    setIsFavorite,
   } = useShelterDetail(id);
 
-  // Toast 상태 추가
   const [toast, setToast] = useState<{ open: boolean; message: string }>({
     open: false,
     message: '',
@@ -36,27 +35,29 @@ const ShelterDetailPage = () => {
     setTimeout(() => setToast({ open: false, message: '' }), 1500);
   };
 
-  // 찜 버튼 클릭 핸들러
-  const handleToggleFavorite = () => {
-    onToggleFavorite();
-    if (isFavorite) {
-      showToast('찜 목록에서\n삭제되었습니다');
-    } else {
-      showToast('찜 목록에\n추가되었습니다');
+  // wishApi를 활용한 찜 버튼 클릭 핸들러
+  const handleToggleFavorite = async () => {
+    const userId = 1; // TODO: 실제 서비스에서는 인증 정보에서 받아야 함
+    const result = await toggleWish({
+      shelterId: id ?? '',
+      userId,
+      isFavorite,
+    });
+    // 찜 추가/삭제 성공 시 하트 상태 변경
+    if (result.success) {
+      setIsFavorite(!isFavorite);
     }
+    showToast(result.message);
   };
 
-  // 로딩 중일 때의 UI
   if (isLoading) {
     return <div>로딩 중...</div>;
   }
 
   return (
     <div css={container}>
-      {/* Toast 메시지 */}
       {toast.open && <ToastMessage message={toast.message} />}
 
-      {/* 쉼터 정보 컴포넌트 */}
       {shelter && (
         <ShelterDetailInfo
           shelter={shelter}
@@ -68,7 +69,6 @@ const ShelterDetailPage = () => {
         />
       )}
 
-      {/* 리뷰 섹션 컴포넌트 */}
       <ShelterReviewSection
         reviews={reviews}
         loading={loadingReviews}
@@ -82,7 +82,6 @@ const ShelterDetailPage = () => {
 
 export default ShelterDetailPage;
 
-/* 페이지 전체 컨테이너 스타일 */
 const container = css`
   padding: 16px;
   margin-top: 0px;

--- a/web/src/pages/WishListPage/components/WishListCard.tsx
+++ b/web/src/pages/WishListPage/components/WishListCard.tsx
@@ -1,0 +1,152 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { FaHeart } from 'react-icons/fa';
+import NoImage from '@/assets/images/NoImage.png';
+import theme from '@/styles/theme';
+
+interface WishShelter {
+  shelterId: number;
+  name: string;
+  address: string;
+  operatingHours: string;
+  averageRating: number;
+  photoUrl: string;
+  distance: string;
+}
+
+interface WishListCardProps {
+  item: WishShelter;
+  onClick: (shelterId: number) => void;
+}
+
+const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+  event.currentTarget.src = NoImage;
+};
+
+const WishListCard = ({ item, onClick }: WishListCardProps) => (
+  <div css={card} onClick={() => onClick(item.shelterId)} style={{ cursor: 'pointer' }}>
+    <div css={cardTitleRow}>
+      <span css={cardTitle}>{item.name}</span>
+      <FaHeart color="red" size={30} css={cardHeart} />
+    </div>
+    <div css={cardBottomRow}>
+      <img
+        src={item.photoUrl && item.photoUrl.trim() !== '' ? item.photoUrl : NoImage}
+        alt="찜 이미지"
+        css={cardImg}
+        onError={handleImageError}
+      />
+      <div css={cardInfo}>
+        <div css={cardRating}>
+          별점: <span css={ratingNumber}>{item.averageRating}</span>
+          <span css={starsWrapper}>
+            {Array.from({ length: 5 }, (_, i) => (
+              <span key={i} css={i < Math.round(item.averageRating) ? filledStar : emptyStar}>
+                ★
+              </span>
+            ))}
+          </span>
+        </div>
+        <div css={cardinfostyle}>
+          거리: {item.distance}
+          <br />
+          운영시간: {item.operatingHours}
+          <br />
+          주소: {item.address}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const card = css`
+  background: #e0e0e0;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+`;
+
+const cardTitleRow = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 16px 8px 16px;
+`;
+
+const cardTitle = css`
+  ${theme.typography.wish2};
+  padding-bottom: 4px;
+`;
+
+const cardHeart = css`
+  font-size: ${theme.typography.wish1};
+  padding-bottom: 4px;
+`;
+
+const cardBottomRow = css`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 0 16px;
+`;
+
+const cardImg = css`
+  width: 30%;
+  height: 30%;
+  object-fit: cover;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const cardInfo = css`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+`;
+
+const cardRating = css`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+const ratingNumber = css`
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.red};
+`;
+
+const starsWrapper = css`
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+const filledStar = css`
+  color: #ffd700;
+  ${theme.typography.wish3};
+`;
+
+const emptyStar = css`
+  color: #bbb;
+  ${theme.typography.wish3};
+`;
+
+const cardinfostyle = css`
+  text-align: left;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+export default WishListCard;

--- a/web/src/pages/WishListPage/components/WishListCard.tsx
+++ b/web/src/pages/WishListPage/components/WishListCard.tsx
@@ -6,6 +6,7 @@ import theme from '@/styles/theme';
 import { formatOperatingHours } from '@/utils/date';
 import { useState } from 'react';
 import ToastMessage from '@/pages/FindSheltersPage/components/ToastMessage';
+import { toggleWish } from '@/utils/wishApi';
 
 interface WishShelter {
   shelterId: number;
@@ -36,38 +37,29 @@ const WishListCard = ({ item, onClick }: WishListCardProps) => {
     if (isFavorite) {
       setShowModal(true);
     } else {
-      // 찜 추가 (POST)
-      try {
-        await fetch(`/api/users/1/wishes/${item.shelterId}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            shelterId: item.shelterId,
-            userId: 1, // TODO: 실제 userId는 인증 정보에서 받아야 함
-          }),
-        });
-        setIsFavorite(true);
-        setToastMessage('찜 목록에\n추가되었습니다.');
-        setTimeout(() => setToastMessage(''), 2000);
-      } catch (err) {
-        // TODO: 에러 처리 필요
-      }
+      // wishApi를 사용해 찜 추가
+      const result = await toggleWish({
+        shelterId: item.shelterId,
+        userId: 1, // 실제 서비스에서는 인증 정보에서 받아야 함
+        isFavorite: false,
+      });
+      if (result.success) setIsFavorite(true);
+      setToastMessage(result.message);
+      setTimeout(() => setToastMessage(''), 2000);
     }
   };
 
   const handleConfirm = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    // 찜 삭제 (DELETE)
-    try {
-      await fetch(`/api/users/1/wishes/${item.shelterId}`, {
-        method: 'DELETE',
-      });
-      setIsFavorite(false);
-      setToastMessage('찜 목록에서\n삭제되었습니다.');
-      setTimeout(() => setToastMessage(''), 2000);
-    } catch (err) {
-      // TODO: 에러 처리 필요
-    }
+    // wishApi를 사용해 찜 삭제
+    const result = await toggleWish({
+      shelterId: item.shelterId,
+      userId: 1,
+      isFavorite: true,
+    });
+    if (result.success) setIsFavorite(false);
+    setToastMessage(result.message);
+    setTimeout(() => setToastMessage(''), 2000);
     setShowModal(false);
   };
 
@@ -130,7 +122,6 @@ const WishListCard = ({ item, onClick }: WishListCardProps) => {
           </div>
         </div>
       )}
-      {/* ToastMessage 컴포넌트로 안내 팝업 표시 */}
       <ToastMessage message={toastMessage} />
     </div>
   );

--- a/web/src/pages/WishListPage/components/WishListCard.tsx
+++ b/web/src/pages/WishListPage/components/WishListCard.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { FaHeart } from 'react-icons/fa';
 import NoImage from '@/assets/images/NoImage.png';
 import theme from '@/styles/theme';
+import { formatOperatingHours } from '@/utils/date';
 
 interface WishShelter {
   shelterId: number;
@@ -50,7 +51,7 @@ const WishListCard = ({ item, onClick }: WishListCardProps) => (
         <div css={cardinfostyle}>
           거리: {item.distance}
           <br />
-          운영시간: {item.operatingHours}
+          운영시간: {formatOperatingHours(item.operatingHours)}
           <br />
           주소: {item.address}
         </div>

--- a/web/src/pages/WishListPage/components/WishListCard.tsx
+++ b/web/src/pages/WishListPage/components/WishListCard.tsx
@@ -40,7 +40,7 @@ const WishListCard = ({ item, onClick }: WishListCardProps) => {
       // wishApi를 사용해 찜 추가
       const result = await toggleWish({
         shelterId: item.shelterId,
-        userId: 1, // 실제 서비스에서는 인증 정보에서 받아야 함
+        userId: 1, // TODO: 실제 서비스에서는 인증 정보에서 받아야 함
         isFavorite: false,
       });
       if (result.success) setIsFavorite(true);

--- a/web/src/pages/WishListPage/index.tsx
+++ b/web/src/pages/WishListPage/index.tsx
@@ -1,4 +1,255 @@
-const WishListPage = () => {
-  return <div>찜 목록 페이지 (구현 예정)</div>;
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { FaHeart } from 'react-icons/fa';
+import NoImage from '@/assets/images/NoImage.png';
+import emptyWishImg from '@/assets/images/empty-wish.png';
+import theme from '@/styles/theme';
+
+// API 명세에 맞는 타입 정의
+interface WishShelter {
+  shelterId: number;
+  name: string;
+  address: string;
+  operatingHours: string;
+  averageRating: number;
+  photoUrl: string;
+  distance: string;
+}
+
+// 목데이터 (API 응답 형태와 동일)
+const mockWishList: WishShelter[] = [
+  {
+    shelterId: 1,
+    name: '종로 무더위 쉼터',
+    address: '서울 종로구 세종대로 175',
+    operatingHours: '09:00~18:00',
+    averageRating: 4.5,
+    photoUrl: 'https://example.com/shelter1.jpg',
+    distance: '250m',
+  },
+  {
+    shelterId: 2,
+    name: '강남 무더위 쉼터',
+    address: '서울 강남구 테헤란로 123',
+    operatingHours: '09:00~18:00',
+    averageRating: 4.2,
+    photoUrl: '',
+    distance: '1.2km',
+  },
+];
+
+const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+  event.currentTarget.src = NoImage; // 이미지 로드 실패 시 NoImage로 대체
 };
+
+const WishListPage = () => {
+  const wishList = mockWishList; // TODO: 추후 API 연결 시 변경
+
+  return (
+    <div css={container}>
+      <div css={header}>
+        <FaHeart color="red" size={43} css={heartIcon} />
+        <span css={title}>찜 목록</span>
+      </div>
+      {wishList.length === 0 ? (
+        <div css={emptyBox}>
+          <img src={emptyWishImg} alt="찜 없음" css={emptyImg} />
+          <div css={emptyText}>찜이 없습니다.</div>
+        </div>
+      ) : (
+        <div css={listBox}>
+          {wishList.map((item) => (
+            <div key={item.shelterId} css={card}>
+              <div css={cardTitleRow}>
+                <span css={cardTitle}>{item.name}</span>
+                <FaHeart color="red" size={30} css={cardHeart} />
+              </div>
+              <div css={cardBottomRow}>
+                <img
+                  src={item.photoUrl && item.photoUrl.trim() !== '' ? item.photoUrl : NoImage}
+                  alt="찜 이미지"
+                  css={cardImg}
+                  onError={handleImageError}
+                />
+                <div css={cardInfo}>
+                  <div css={cardRating}>
+                    별점: <span css={ratingNumber}>{item.averageRating}</span>
+                    <span css={starsWrapper}>
+                      {Array.from({ length: 5 }, (_, i) => (
+                        <span
+                          key={i}
+                          css={i < Math.round(item.averageRating) ? filledStar : emptyStar}
+                        >
+                          ★
+                        </span>
+                      ))}
+                    </span>
+                  </div>
+                  <div css={cardinfostyle}>
+                    거리: {item.distance}
+                    <br />
+                    운영시간: {item.operatingHours}
+                    <br />
+                    주소: {item.address}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 export default WishListPage;
+
+// 스타일
+const container = css`
+  background: #fff;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 0px;
+`;
+
+const header = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-left: 16px;
+  box-sizing: border-box;
+`;
+
+const heartIcon = css`
+  font-size: ${theme.typography.wish1};
+`;
+
+const title = css`
+  ${theme.typography.wish1};
+  text-shadow: 2px 2px 6px #bbb;
+`;
+
+const listBox = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 95%;
+`;
+
+const card = css`
+  background: #e0e0e0;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+`;
+
+const cardTitleRow = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between; // 추가
+  gap: 8px;
+  padding: 0 16px 8px 16px;
+`;
+
+const cardTitle = css`
+  ${theme.typography.wish2};
+  padding-bottom: 4px;
+`;
+
+const cardHeart = css`
+  font-size: ${theme.typography.wish1};
+  padding-bottom: 4px;
+`;
+
+const cardBottomRow = css`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 0 16px;
+`;
+
+const cardImg = css`
+  width: 30%;
+  height: 30%;
+  object-fit: cover;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const cardInfo = css`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+`;
+
+const cardRating = css`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+const ratingNumber = css`
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.red};
+`;
+
+const starsWrapper = css`
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+const filledStar = css`
+  color: #ffd700;
+  ${theme.typography.wish3};
+`;
+
+const emptyStar = css`
+  color: #bbb;
+  ${theme.typography.wish3};
+`;
+
+const cardinfostyle = css`
+  text-align: left;
+  ${theme.typography.wish3};
+  color: ${theme.colors.text.gray500};
+`;
+
+const emptyBox = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 24px;
+  width: 100%;
+`;
+
+const emptyImg = css`
+  width: 160px;
+  height: 160px;
+  object-fit: contain;
+`;
+
+const emptyText = css`
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 2px 2px 6px #222;
+`;

--- a/web/src/pages/WishListPage/index.tsx
+++ b/web/src/pages/WishListPage/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { FaHeart } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
 import NoImage from '@/assets/images/NoImage.png';
 import emptyWishImg from '@/assets/images/empty-wish.png';
 import theme from '@/styles/theme';
@@ -18,7 +19,24 @@ interface WishShelter {
 
 // 목데이터 (API 응답 형태와 동일)
 const mockWishList: WishShelter[] = [
-  // 데이터가 없을 경우 테스트를 위해 빈 배열로 두세요.
+  {
+    shelterId: 1,
+    name: '종로 무더위 쉼터',
+    address: '서울 종로구 세종대로 175',
+    operatingHours: '09:00~18:00',
+    averageRating: 4.5,
+    photoUrl: 'https://example.com/shelter1.jpg',
+    distance: '250m',
+  },
+  {
+    shelterId: 2,
+    name: '강남 무더위 쉼터',
+    address: '서울 강남구 테헤란로 123',
+    operatingHours: '09:00~18:00',
+    averageRating: 4.2,
+    photoUrl: '',
+    distance: '1.2km',
+  },
 ];
 
 const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
@@ -27,6 +45,11 @@ const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
 
 const WishListPage = () => {
   const wishList = mockWishList; // TODO: 추후 API 연결 시 변경
+  const navigate = useNavigate();
+
+  const handleCardClick = (shelterId: number) => {
+    navigate(`/shelter-detail/${shelterId}`);
+  };
 
   return (
     <>
@@ -39,7 +62,12 @@ const WishListPage = () => {
           </div>
           <div css={listBox}>
             {wishList.map((item) => (
-              <div key={item.shelterId} css={card}>
+              <div
+                key={item.shelterId}
+                css={card}
+                onClick={() => handleCardClick(item.shelterId)}
+                style={{ cursor: 'pointer' }} // 클릭 가능한 UI 표시
+              >
                 <div css={cardTitleRow}>
                   <span css={cardTitle}>{item.name}</span>
                   <FaHeart color="red" size={30} css={cardHeart} />
@@ -100,7 +128,6 @@ export default WishListPage;
 // 스타일
 const pageContainerStyle = css`
   position: relative;
-  min-height: 100vh;
   margin: 0 auto;
   background: #fff;
   display: flex;

--- a/web/src/pages/WishListPage/index.tsx
+++ b/web/src/pages/WishListPage/index.tsx
@@ -18,100 +18,94 @@ interface WishShelter {
 
 // 목데이터 (API 응답 형태와 동일)
 const mockWishList: WishShelter[] = [
-  {
-    shelterId: 1,
-    name: '종로 무더위 쉼터',
-    address: '서울 종로구 세종대로 175',
-    operatingHours: '09:00~18:00',
-    averageRating: 4.5,
-    photoUrl: 'https://example.com/shelter1.jpg',
-    distance: '250m',
-  },
-  {
-    shelterId: 2,
-    name: '강남 무더위 쉼터',
-    address: '서울 강남구 테헤란로 123',
-    operatingHours: '09:00~18:00',
-    averageRating: 4.2,
-    photoUrl: '',
-    distance: '1.2km',
-  },
+  // 데이터가 없을 경우 테스트를 위해 빈 배열로 두세요.
 ];
 
 const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
-  event.currentTarget.src = NoImage; // 이미지 로드 실패 시 NoImage로 대체
+  event.currentTarget.src = NoImage;
 };
 
 const WishListPage = () => {
   const wishList = mockWishList; // TODO: 추후 API 연결 시 변경
 
   return (
-    <div css={container}>
-      <div css={header}>
-        <FaHeart color="red" size={43} css={heartIcon} />
-        <span css={title}>찜 목록</span>
-      </div>
-      {wishList.length === 0 ? (
-        <div css={emptyBox}>
-          <img src={emptyWishImg} alt="찜 없음" css={emptyImg} />
-          <div css={emptyText}>찜이 없습니다.</div>
-        </div>
-      ) : (
-        <div css={listBox}>
-          {wishList.map((item) => (
-            <div key={item.shelterId} css={card}>
-              <div css={cardTitleRow}>
-                <span css={cardTitle}>{item.name}</span>
-                <FaHeart color="red" size={30} css={cardHeart} />
-              </div>
-              <div css={cardBottomRow}>
-                <img
-                  src={item.photoUrl && item.photoUrl.trim() !== '' ? item.photoUrl : NoImage}
-                  alt="찜 이미지"
-                  css={cardImg}
-                  onError={handleImageError}
-                />
-                <div css={cardInfo}>
-                  <div css={cardRating}>
-                    별점: <span css={ratingNumber}>{item.averageRating}</span>
-                    <span css={starsWrapper}>
-                      {Array.from({ length: 5 }, (_, i) => (
-                        <span
-                          key={i}
-                          css={i < Math.round(item.averageRating) ? filledStar : emptyStar}
-                        >
-                          ★
-                        </span>
-                      ))}
-                    </span>
-                  </div>
-                  <div css={cardinfostyle}>
-                    거리: {item.distance}
-                    <br />
-                    운영시간: {item.operatingHours}
-                    <br />
-                    주소: {item.address}
+    <>
+      {wishList.length > 0 ? (
+        // 찜 목록이 있을 때 컨테이너
+        <div css={pageContainerStyle}>
+          <div css={header}>
+            <FaHeart color="red" size={43} css={heartIcon} />
+            <span css={title}>찜 목록</span>
+          </div>
+          <div css={listBox}>
+            {wishList.map((item) => (
+              <div key={item.shelterId} css={card}>
+                <div css={cardTitleRow}>
+                  <span css={cardTitle}>{item.name}</span>
+                  <FaHeart color="red" size={30} css={cardHeart} />
+                </div>
+                <div css={cardBottomRow}>
+                  <img
+                    src={item.photoUrl && item.photoUrl.trim() !== '' ? item.photoUrl : NoImage}
+                    alt="찜 이미지"
+                    css={cardImg}
+                    onError={handleImageError}
+                  />
+                  <div css={cardInfo}>
+                    <div css={cardRating}>
+                      별점: <span css={ratingNumber}>{item.averageRating}</span>
+                      <span css={starsWrapper}>
+                        {Array.from({ length: 5 }, (_, i) => (
+                          <span
+                            key={i}
+                            css={i < Math.round(item.averageRating) ? filledStar : emptyStar}
+                          >
+                            ★
+                          </span>
+                        ))}
+                      </span>
+                    </div>
+                    <div css={cardinfostyle}>
+                      거리: {item.distance}
+                      <br />
+                      운영시간: {item.operatingHours}
+                      <br />
+                      주소: {item.address}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
+        </div>
+      ) : (
+        // 찜 목록이 없을 때 컨테이너
+        <div css={emptyStateStyle}>
+          <div css={emptyHeader}>
+            <FaHeart color="red" size={43} css={heartIcon} />
+            <span css={emptyTitle}>찜 목록</span>
+          </div>
+          <div css={emptyBox}>
+            <div css={emptyText}>찜이 없습니다.</div>
+            <img src={emptyWishImg} alt="찜 없음" css={emptyImg} />
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 };
 
 export default WishListPage;
 
 // 스타일
-const container = css`
+const pageContainerStyle = css`
+  position: relative;
+  min-height: 100vh;
+  margin: 0 auto;
   background: #fff;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 0px;
 `;
 
 const header = css`
@@ -132,6 +126,7 @@ const heartIcon = css`
 const title = css`
   ${theme.typography.wish1};
   text-shadow: 2px 2px 6px #bbb;
+  color: #222;
 `;
 
 const listBox = css`
@@ -155,7 +150,7 @@ const card = css`
 const cardTitleRow = css`
   display: flex;
   align-items: center;
-  justify-content: space-between; // 추가
+  justify-content: space-between;
   gap: 8px;
   padding: 0 16px 8px 16px;
 `;
@@ -231,24 +226,52 @@ const cardinfostyle = css`
   color: ${theme.colors.text.gray500};
 `;
 
+const emptyStateStyle = css`
+  position: fixed;
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  text-align: center;
+  background: #000;
+  overflow: hidden;
+`;
+
+const emptyHeader = css`
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-left: 16px;
+  box-sizing: border-box;
+`;
+
+const emptyTitle = css`
+  ${theme.typography.wish1};
+  color: #fff;
+  text-shadow: 2px 2px 6px #222;
+`;
+
 const emptyBox = css`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 60vh;
   gap: 24px;
   width: 100%;
 `;
 
 const emptyImg = css`
   width: 160px;
-  height: 160px;
+  height: auto;
   object-fit: contain;
 `;
 
 const emptyText = css`
-  font-size: 1.6rem;
+  padding-top: 20%;
+  font-size: 2.2rem;
   font-weight: 700;
   color: #fff;
   text-shadow: 2px 2px 6px #222;

--- a/web/src/pages/WishListPage/index.tsx
+++ b/web/src/pages/WishListPage/index.tsx
@@ -2,9 +2,9 @@
 import { css } from '@emotion/react';
 import { FaHeart } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
-import NoImage from '@/assets/images/NoImage.png';
 import emptyWishImg from '@/assets/images/empty-wish.png';
 import theme from '@/styles/theme';
+import WishListCard from './components/WishListCard';
 
 // API 명세에 맞는 타입 정의
 interface WishShelter {
@@ -39,10 +39,6 @@ const mockWishList: WishShelter[] = [
   },
 ];
 
-const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
-  event.currentTarget.src = NoImage;
-};
-
 const WishListPage = () => {
   const wishList = mockWishList; // TODO: 추후 API 연결 시 변경
   const navigate = useNavigate();
@@ -62,47 +58,7 @@ const WishListPage = () => {
           </div>
           <div css={listBox}>
             {wishList.map((item) => (
-              <div
-                key={item.shelterId}
-                css={card}
-                onClick={() => handleCardClick(item.shelterId)}
-                style={{ cursor: 'pointer' }} // 클릭 가능한 UI 표시
-              >
-                <div css={cardTitleRow}>
-                  <span css={cardTitle}>{item.name}</span>
-                  <FaHeart color="red" size={30} css={cardHeart} />
-                </div>
-                <div css={cardBottomRow}>
-                  <img
-                    src={item.photoUrl && item.photoUrl.trim() !== '' ? item.photoUrl : NoImage}
-                    alt="찜 이미지"
-                    css={cardImg}
-                    onError={handleImageError}
-                  />
-                  <div css={cardInfo}>
-                    <div css={cardRating}>
-                      별점: <span css={ratingNumber}>{item.averageRating}</span>
-                      <span css={starsWrapper}>
-                        {Array.from({ length: 5 }, (_, i) => (
-                          <span
-                            key={i}
-                            css={i < Math.round(item.averageRating) ? filledStar : emptyStar}
-                          >
-                            ★
-                          </span>
-                        ))}
-                      </span>
-                    </div>
-                    <div css={cardinfostyle}>
-                      거리: {item.distance}
-                      <br />
-                      운영시간: {item.operatingHours}
-                      <br />
-                      주소: {item.address}
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <WishListCard key={item.shelterId} item={item} onClick={handleCardClick} />
             ))}
           </div>
         </div>
@@ -161,96 +117,6 @@ const listBox = css`
   flex-direction: column;
   gap: 12px;
   width: 95%;
-`;
-
-const card = css`
-  background: #e0e0e0;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  overflow: hidden;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  padding: 12px 0;
-`;
-
-const cardTitleRow = css`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 0 16px 8px 16px;
-`;
-
-const cardTitle = css`
-  ${theme.typography.wish2};
-  padding-bottom: 4px;
-`;
-
-const cardHeart = css`
-  font-size: ${theme.typography.wish1};
-  padding-bottom: 4px;
-`;
-
-const cardBottomRow = css`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 0 16px;
-`;
-
-const cardImg = css`
-  width: 30%;
-  height: 30%;
-  object-fit: cover;
-  border-radius: 8px;
-  background: #fafafa;
-`;
-
-const cardInfo = css`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-`;
-
-const cardRating = css`
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  ${theme.typography.wish3};
-  color: ${theme.colors.text.gray500};
-`;
-
-const ratingNumber = css`
-  ${theme.typography.wish3};
-  color: ${theme.colors.text.red};
-`;
-
-const starsWrapper = css`
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  ${theme.typography.wish3};
-  color: ${theme.colors.text.gray500};
-`;
-
-const filledStar = css`
-  color: #ffd700;
-  ${theme.typography.wish3};
-`;
-
-const emptyStar = css`
-  color: #bbb;
-  ${theme.typography.wish3};
-`;
-
-const cardinfostyle = css`
-  text-align: left;
-  ${theme.typography.wish3};
-  color: ${theme.colors.text.gray500};
 `;
 
 const emptyStateStyle = css`

--- a/web/src/styles/typography.ts
+++ b/web/src/styles/typography.ts
@@ -93,7 +93,7 @@ export const typography = {
 
   // 마이페이지 (MyPage)
   my1: {
-    fontSize: '5vh', // 마이페이지 타이틀
+    fontSize: '4.5vh', // 마이페이지 타이틀
     fontWeight: 700,
     lineHeight: '6vh',
   },
@@ -111,6 +111,23 @@ export const typography = {
     fontSize: '3.8vh', // 로그아웃 버튼
     fontWeight: 700,
     lineHeight: '4.1vh',
+  },
+
+  //wishlist 페이지 (WishListPage)
+  wish1: {
+    fontSize: '4.5vh', // "찜 목록" 타이틀
+    fontWeight: 700,
+    lineHeight: '6vh',
+  },
+  wish2: {
+    fontSize: '3vh', // 찜 목록 내 쉼터 이름
+    fontWeight: 800,
+    lineHeight: '3.72vh',
+  },
+  wish3: {
+    fontSize: '2.26vh', // 찜 목록 내 거리, 운영시간
+    fontWeight: 600,
+    lineHeight: '2.84vh',
   },
 
   //버튼 (Button)

--- a/web/src/utils/wishApi.ts
+++ b/web/src/utils/wishApi.ts
@@ -1,0 +1,31 @@
+export async function toggleWish({
+  shelterId,
+  userId,
+  isFavorite,
+}: {
+  shelterId: number | string;
+  userId: number;
+  isFavorite: boolean;
+}) {
+  if (isFavorite) {
+    // 찜 삭제 (DELETE)
+    const res = await fetch(`/api/users/${userId}/wishes/${shelterId}`, {
+      method: 'DELETE',
+    });
+    if (res.status === 204) {
+      return { success: true, message: '찜 목록에서\n삭제되었습니다' };
+    }
+    return { success: false, message: '삭제에 실패했습니다' };
+  } else {
+    // 찜 추가 (POST)
+    const res = await fetch(`/api/users/${userId}/wishes/${shelterId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ shelterId, userId }),
+    });
+    if (res.ok) {
+      return { success: true, message: '찜 목록에\n추가되었습니다' };
+    }
+    return { success: false, message: '추가에 실패했습니다' };
+  }
+}


### PR DESCRIPTION
## 🚀 작업 내용
### #41 찜 목록 페이지 구현

- [x] 기능 추가(찜 목록 페이지 구현)
- [x] 버그 수정(쉼터 상세 페이지-더보기/접기 버튼 오류 수정)
- [x] 리팩토링(찜 api 별도 파일로 관리)

## 📝 상세 내용
#### 1. 쉼터 상세 페이지
- 리뷰 내용이 3줄 미만일 경우 → 더보기/접기 버튼 숨기도록 수정
- 찜 관련 인터페이스를 명세에 맞게 수정

#### 2. 찜 목록 페이지
- 찜 목록 페이지 구현
- 찜이 없을 경우 전용 페이지 표시
- 상세 페이지로 라우팅 가능하도록 구현
- 찜 카드 컴포넌트 분리 → 이후 내가 쓴 리뷰 페이지에서 재사용 예정?
- 찜 버튼 삭제 동작(현재는 하트만 비워두는 방식, 삭제했으면 페이지에서 없애는게 나을지 냅두는게 나을지)

#### 3. 코드 구조 개선
- 찜 관련 API를 util/wishApi.ts 파일로 분리
- 찜과 관련된 페이지에서 모두 해당 API를 사용하도록 수정
    - 가까운 쉼터 찾기 페이지
    - 쉼터 상세 페이지
    - 찜 목록 페이지

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/6b766e73-543a-4dce-b8fd-8f5905c7afc6

- 찜 하트 클릭 시 "찜 목록에서 삭제하겠습니까?" 팝업 표시
- "예" 클릭 시 "찜 목록에서 삭제되었습니다"가 출력되어야 하는데 현재 api 연동을 안한 상태여서 "삭제에 실패하였습니다"가 뜨는게 정상
- "아니요" 클릭 시 화면에서 아무런 변화 없음
- 쉼터 상세 페이지 라우팅 연결


## 💡 참고 사항
- 재사용을 하는게 맞을까요? 그냥 새로 구현해도 될 거 같기도...?
- 쉼터 찜 목록에 개수가 많을 경우 스크롤이 자동으로 생깁니다! 더보기 버튼보다는 스크롤이 나은 거 같아요!
<img width="150" height="350" alt="image" src="https://github.com/user-attachments/assets/779c79b7-9df8-4b66-836b-ce94c5d3aa3f" />
