### PR TITLE
CI/CD를 통해 APK 빌드 과정을 자동화

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -50,11 +50,17 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
+      - name: Prepare named APK (branch + short SHA)
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          DEST="app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}-${SHORT_SHA}.apk"
+          cp app/app/build/outputs/apk/debug/*.apk "$DEST"
+
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-apk
-          path: app/app/build/outputs/apk/debug/*.apk
+          name: app-debug-apk-${{ github.ref_name }}-${{ env.SHORT_SHA }}
+          path: app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}-${{ env.SHORT_SHA }}.apk
           if-no-files-found: error
 
   release-on-tag:

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -3,7 +3,12 @@ name: Android APK
 on:
   push:
     branches: [develop, main]
+    paths:
+      - "app/**"
   pull_request:
+    branches: [develop, main]
+    paths:
+      - "app/**"
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Prepare named APK (branch + short SHA)
         run: |
-          echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
-          DEST="app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}-${SHORT_SHA}.apk"
+          SHORT_SHA=${GITHUB_SHA::7}
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          DEST="app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}-$SHORT_SHA.apk"
           cp app/app/build/outputs/apk/debug/*.apk "$DEST"
 
       - name: Upload APK artifact

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -11,6 +11,10 @@ on:
       - "app/**"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-debug-apk:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,0 +1,46 @@
+name: Android APK
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+  workflow_dispatch: {}
+
+jobs:
+  build-debug-apk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platforms and build tools
+        run: |
+          sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v3
+        with:
+          build-root-directory: app
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           build-root-directory: app
 
+      - name: Ensure gradlew is executable
+        run: chmod +x ./gradlew
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
@@ -44,3 +47,19 @@ jobs:
           name: app-debug-apk
           path: app/app/build/outputs/apk/debug/*.apk
           if-no-files-found: error
+
+  release-on-tag:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-debug-apk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-debug-apk
+          path: apk
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apk/*.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -47,5 +47,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: app/app/build/outputs/apk/debug/*.apk
+          files: app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
           generate_release_notes: true
+
+      - name: Rename APK with tag
+        run: |
+          mv app/app/build/outputs/apk/debug/*.apk app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
+      - name: Rename APK with tag
+        run: |
+          mv app/app/build/outputs/apk/debug/*.apk app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
           generate_release_notes: true
-
-      - name: Rename APK with tag
-        run: |
-          mv app/app/build/outputs/apk/debug/*.apk app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,51 @@
+name: Android Release APK
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-apk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platforms and build tools
+        run: |
+          sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v3
+        with:
+          build-root-directory: app
+
+      - name: Ensure gradlew is executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app/app/build/outputs/apk/debug/*.apk
+          generate_release_notes: true


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #34 

## 💬 팀원에게 한마디

- 간단히 요약하자면, app폴더에 수정사항이 있는 상태로 develop이나 main에 push하면 apk가 빌드됩니다.
- github 레포지토리 우측 사이드바의 releases에 apk를 올리려면 다음과 같은 명령어를 git에 입력합니다.
`git tag v1.0.0 && git push origin v1.0.0`

- 아직 테스트를 안해봐서 제대로 될지 모르겠네요..!