### PR TITLE
Fix: CI/CD를 통해 APK 빌드 과정을 자동화 (수정3)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Rename APK with tag
         run: |
-          mv app/app/build/outputs/apk/debug/*.apk app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
+          mv app/build/outputs/apk/debug/*.apk app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: app/app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
+          files: app/build/outputs/apk/debug/app-debug-${{ github.ref_name }}.apk
           generate_release_notes: true


### PR DESCRIPTION
## 🔗 관련 이슈

#34

## 💬 팀원에게 한마디

기존 pr(https://github.com/kakao-tech-campus-3rd-step3/Team19_FE/pull/59 )에 대한 수정 pr입니다.
~~#66 이후 뭔가 문제가 생겼는지 아직 변경사항이 남아있네요. 다시 pr보냈습니다.~~
~~#67 이후에도 안되서 다시 시도합니다. 제발...~~
#68 이후에도 똑같아서 그냥 feature/34브랜치 버리고 feature/34-ci-fix라는 새로운 브랜치를 파서 pr 보냅니다.
