### PR TITLE
찜 목록 페이지에서 api내용 화면에 그리기

### DIFF
--- a/web/src/pages/WishListPage/index.tsx
+++ b/web/src/pages/WishListPage/index.tsx
@@ -20,7 +20,9 @@ const WishListPage = () => {
     setIsLoading(true);
     getWishList()
       .then((data: any) => {
-        if (mounted) setWishList(Array.isArray(data) ? data : []);
+        if (!mounted) return;
+        const items = Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : [];
+        setWishList(items);
       })
       .catch((e) => {
         if (mounted) setError(e);
@@ -59,7 +61,10 @@ const WishListPage = () => {
                 onClick={handleCardClick}
                 refetchWishList={() =>
                   getWishList()
-                    .then((d: any) => setWishList(Array.isArray(d) ? d : []))
+                    .then((d: any) => {
+                      const items = Array.isArray(d?.items) ? d.items : Array.isArray(d) ? d : [];
+                      setWishList(items);
+                    })
                     .catch(() => {
                       /* optional: set error state if needed */
                     })


### PR DESCRIPTION
fix(wishlist): 서버 응답 {items: []} 파싱하도록 수정해 목록 표시
- 초기 로딩 및 refetch 시 data.items(배열) 우선 사용, 배열 fallback 처리
- 응답 구조 불일치로 목록이 렌더링되지 않던 문제 해결
- 변경: web/src/pages/WishListPage/index.tsx

## 🔗 관련 이슈

Closes #120
